### PR TITLE
Update test_log.txt path

### DIFF
--- a/integrationHelperParser.js
+++ b/integrationHelperParser.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 //Integration helper logs file, passed from tam-tool.js
-const filename = fs.readFileSync('/Users/edwinbetancourt/edwinB-TAM/TAM-ToolJS/test_log.txt').toString();
+const filename = fs.readFileSync('test_log.txt').toString();
 //Compiled Network and Adapter matches into one regex
 const network_adapter = /\B([-]{15})\s([a-zA-Z]\w*)\s+([-]{14})\n(.+?(?:((Adapter\s)([0-9.]+\S))\s))/g;
 // Empty Adapter


### PR DESCRIPTION
Ensuring that the path for readFileSync utilizes the local test_log.txt and not an absolute path to one that doesn't exist on other users' local workspaces